### PR TITLE
Extended `climateAssessmentConfig`, `emissionDataForClimateAssessment`

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '121080'
+ValidationKey: '141344'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'remindClimateAssessment: REMIND integration of IIASA''s `climate-assessment`
   package'
-version: 0.0.6
-date-released: '2025-04-02'
+version: 0.0.7
+date-released: '2025-04-14'
 abstract: The REMIND integration of IIASA's `climate-assessment` provides a standardized
   interface to simple climate models such as MAGICC7.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remindClimateAssessment
 Title: REMIND integration of IIASA's `climate-assessment` package
-Version: 0.0.6
-Date: 2025-04-02
+Version: 0.0.7
+Date: 2025-04-14
 Authors@R:
     person("Tonn", "Rüter", , "tonn.rueter@pik-potsdam.de", role = c("aut", "cre"))
 Description: The REMIND integration of IIASA's `climate-assessment` provides a standardized interface to simple climate models such as MAGICC7.

--- a/R/climateAssessmentConfig.R
+++ b/R/climateAssessmentConfig.R
@@ -3,7 +3,7 @@
 #' Collects all necessary files and directories to set up climate assessment run from a REMIND output directory
 #'
 #' @param outputDir A REMIND output directory
-#' @param mode Determines which probabiliy files is used. Must be either "report", "iteration", or a valid path
+#' @param mode Determines which probabiliy files is used. Must be either "report", "iteration" or "impulse"
 #'
 #' @return A list containing the configuration settings for the climate assessment
 # nolint start
@@ -32,7 +32,7 @@
 #' @importFrom magrittr %>%
 #' @export
 climateAssessmentConfig <- function(outputDir, mode) {
-  if (!(mode %in% c("report", "iteration")) || file.exists(mode))
+  if (!(mode %in% c("report", "iteration", "impulse")) || file.exists(mode))
     stop("'mode' must be either 'report', 'iteration', 'impulse', or valid path")
   runConfig <- read_yaml(file.path(outputDir, "cfg.txt"))
   cfg <- list(

--- a/R/climateAssessmentConfig.R
+++ b/R/climateAssessmentConfig.R
@@ -98,5 +98,35 @@ climateAssessmentConfig <- function(outputDir, mode) {
     ),
     mustWork = FALSE
   )
+  # Climate assessment generates files with `_excluded_scenarios_` in the file name in case certain checks did not pass
+  # Error checking idiom could look like any(file.exists(cfg$excludedScenarioFiles))
+  cfg$excludedScenarioFiles <- c(
+    # From ca docs: Writing out scenarios with no confidence due to reporting completeness issues
+    "No Confidence" = normalizePath(
+      file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_excluded_scenarios_noconfidence.csv")),
+      mustWork = FALSE
+    ),
+    # No Emissions|CO2 or Emissions|CO2|Energy and Industrial Processes found in reporting file
+    "No CO2 reported" = normalizePath(
+      file.path(
+        cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_excluded_scenarios_noCO2orCO2EnIPreported.csv")
+      ),
+      mustWork = FALSE
+    ),
+    # Check against historical data failed
+    "Too far from historical" = normalizePath(
+      file.path(
+        cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_excluded_scenarios_toofarfromhistorical.csv")
+      ),
+      mustWork = FALSE
+    ),
+    # Exclude all scenarios with negative non-CO2 values
+    "Unexpected Negatives" = normalizePath(
+      file.path(
+        cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_excluded_scenarios_unexpectednegatives.csv")
+      ),
+      mustWork = FALSE
+    )
+  )
   return(cfg)
 }

--- a/R/climateAssessmentConfig.R
+++ b/R/climateAssessmentConfig.R
@@ -87,10 +87,19 @@ climateAssessmentConfig <- function(outputDir, mode) {
     NULL
   }
   # Climate assessment generated harmonization and infilling file
-  cfg$harmInfEmissionsFile <- normalizePath(
-    file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_harmonized_infilled.csv")),
-    mustWork = FALSE
-  )
+  cfg$harmInfEmissionsFile <- if (mode == "report") {
+    normalizePath(
+      file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_harmonized_infilled.csv")),
+      mustWork = FALSE
+    )
+  } else {
+    # When running climate assessment in impulse mode the harmonized and infilled emissions file from a previous
+    # iteration run is used. Use the assessmentFilesPrefix from iteration run config here
+    normalizePath(
+      file.path(cfg$climateDir, paste0("ar6_iteration_", cfg$scenario, "_harmonized_infilled.csv")),
+      mustWork = FALSE
+    )
+  }
   # Climate assessment generated output file
   cfg$climateAssessmentFile <- normalizePath(
     file.path(

--- a/R/climateAssessmentConfig.R
+++ b/R/climateAssessmentConfig.R
@@ -29,7 +29,7 @@
 #' )
 #' }
 # nolint end
-#' @importFrom magrittr %>%
+#' @importFrom yaml read_yaml
 #' @export
 climateAssessmentConfig <- function(outputDir, mode) {
   if (!(mode %in% c("report", "iteration", "impulse")) || file.exists(mode))
@@ -66,29 +66,35 @@ climateAssessmentConfig <- function(outputDir, mode) {
   # Some more file needed to run climate assessment
   cfg$parameterSets <- read_yaml(cfg$probabilisticFile)
   cfg$nSets         <- length(cfg$parameterSets$configurations)
+  # Climate assessment files have a different prefix when depending on mode (i.e. run type)
+  assessmentFilesPrefix <- if (mode == "report") {
+    "ar6_climate_assessment_"
+  } else if (mode == "iteration") {
+    "ar6_iteration_"
+  }else {
+    # Must be impulse
+    "ar6_emissions_impulse_"
+  }
   # Emissions file is the output of the harmnonization and infilling step
   cfg$remindEmissionsFile  <- normalizePath(
-    file.path(cfg$climateDir, paste0("ar6_climate_assessment_", cfg$scenario, ".csv")),
+    file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, ".csv")),
     mustWork = FALSE
   )
-  cfg$harmInfEmissionsFile <- normalizePath(
-    file.path(cfg$climateDir, paste0("ar6_climate_assessment_", cfg$scenario, "_harmonized_infilled.csv")),
-    mustWork = FALSE
-  )
+  # Keep this as a separate file to distringuish against the remind emissions file
   cfg$emissionsImpulseFile <- if (mode == "impulse") {
-    normalizePath(file.path(cfg$climateDir, paste0("emissions_impulse_", cfg$scenario, ".xlsx")), mustWork = FALSE)
+    normalizePath(file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, ".xlsx")), mustWork = FALSE)
   } else {
     NULL
   }
-  # Climate assessment file has a different prefix when running in impulse mode. Use this to distinguish between the two
+  # Climate assessment generated harmonization and infilling file
+  cfg$harmInfEmissionsFile <- normalizePath(
+    file.path(cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_harmonized_infilled.csv")),
+    mustWork = FALSE
+  )
+  # Climate assessment generated output file
   cfg$climateAssessmentFile <- normalizePath(
     file.path(
-      cfg$climateDir,
-      if (mode == "impulse") {
-        paste0("emissions_impulse_", cfg$scenario, "_harmonized_infilled_IAMC_climateassessment.xlsx")
-      } else {
-        paste0("ar6_climate_assessment_", cfg$scenario, "_harmonized_infilled_IAMC_climateassessment.xlsx")
-      }
+      cfg$climateDir, paste0(assessmentFilesPrefix, cfg$scenario, "_harmonized_infilled_IAMC_climateassessment.xlsx")
     ),
     mustWork = FALSE
   )

--- a/R/emissionDataForClimateAssessment.R
+++ b/R/emissionDataForClimateAssessment.R
@@ -8,6 +8,8 @@
 #' @md
 #' @param qf `quitte` data frame containing the emission data
 #' @param scenario Name of the scenario
+#' @param mapping Name of the mapping file from the `piamInterfaces` library, must be 'AR6', 'NGFS_AR6' or 'AR6_MAgPIE'.
+#'  Defaults to 'AR6'
 #' @param variablesFile Path to the yaml file containing the variables needed for climate-assessment. If no file path
 #'  is provided, the function gets the yaml file from the piamInterfaces package
 #' @param logFile Path to the log file. Default is "output/missing.log"
@@ -15,7 +17,7 @@
 #' @importFrom quitte is.quitte
 #' @importFrom dplyr filter mutate rename_with
 #' @importFrom tidyr pivot_wider
-#' @importFrom magrittr %>%
+#' @importFrom magrittr %>% %in%
 #' @importFrom stringr str_to_title
 #' @importFrom piamInterfaces generateIIASASubmission
 #' @examples
@@ -33,7 +35,7 @@
 #' }
 #' @author Tonn Rüter
 #' @export
-emissionDataForClimateAssessment <- function(qf, scenario, variablesFile = NULL, logFile = NULL) {
+emissionDataForClimateAssessment <- function(qf, scenario, mapping = "AR6", variablesFile = NULL, logFile = NULL) {
   if (!is.quitte(qf)) {
     stop("remindEmissionReport must be a `quitte` object")
   }
@@ -41,6 +43,9 @@ emissionDataForClimateAssessment <- function(qf, scenario, variablesFile = NULL,
     variablesFile <- normalizePath(file.path(
       system.file(package = "piamInterfaces"), "iiasaTemplates", "climate_assessment_variables.yaml"
     ))
+  }
+  if (!(mapping %in% c("AR6", "NGFS_AR6", "AR6_MAgPIE"))) {
+    stop("mapping must be either 'AR6', 'NGFS_AR6' or 'AR6_MAgPIE' but is '", mapping, "'")
   }
   return(
     qf %>%
@@ -50,7 +55,7 @@ emissionDataForClimateAssessment <- function(qf, scenario, variablesFile = NULL,
       # piamInterfaces package. See also:
       # https://github.com/pik-piam/piamInterfaces/blob/master/inst/iiasaTemplates/climate_assessment_variables.yaml
       generateIIASASubmission(
-        mapping = "AR6",
+        mapping = mapping,
         outputFilename = NULL,
         iiasatemplate = variablesFile,
         logFile = logFile

--- a/R/emissionDataForClimateAssessment.R
+++ b/R/emissionDataForClimateAssessment.R
@@ -17,7 +17,7 @@
 #' @importFrom quitte is.quitte
 #' @importFrom dplyr filter mutate rename_with
 #' @importFrom tidyr pivot_wider
-#' @importFrom magrittr %>% %in%
+#' @importFrom magrittr %>%
 #' @importFrom stringr str_to_title
 #' @importFrom piamInterfaces generateIIASASubmission
 #' @examples

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # REMIND integration of IIASA's `climate-assessment` package
 
-R package **remindClimateAssessment**, version **0.0.6**
+R package **remindClimateAssessment**, version **0.0.7**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remindClimateAssessment)](https://cran.r-project.org/package=remindClimateAssessment) [![R build status](https://github.com/pik-piam/remindClimateAssessment/workflows/check/badge.svg)](https://github.com/pik-piam/remindClimateAssessment/actions) [![codecov](https://codecov.io/gh/pik-piam/remindClimateAssessment/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remindClimateAssessment) 
+[![CRAN status](https://www.r-pkg.org/badges/version/remindClimateAssessment)](https://cran.r-project.org/package=remindClimateAssessment) [![R build status](https://github.com/pik-piam/remindClimateAssessment/workflows/check/badge.svg)](https://github.com/pik-piam/remindClimateAssessment/actions) [![codecov](https://codecov.io/gh/pik-piam/remindClimateAssessment/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remindClimateAssessment) [![r-universe](https://pik-piam.r-universe.dev/badges/remindClimateAssessment)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Tonn Rüter <tonn.rueter@pik-pots
 
 To cite package **remindClimateAssessment** in publications use:
 
-Rüter T (2025). "remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package." Version: 0.0.6, <https://github.com/pik-piam/remindClimateAssessment>.
+Rüter T (2025). "remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package." Version: 0.0.7, <https://github.com/pik-piam/remindClimateAssessment>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package},
   author = {Tonn Rüter},
-  date = {2025-04-02},
+  date = {2025-04-14},
   year = {2025},
   url = {https://github.com/pik-piam/remindClimateAssessment},
-  note = {Version: 0.0.6},
+  note = {Version: 0.0.7},
 }
 ```

--- a/man/climateAssessmentConfig.Rd
+++ b/man/climateAssessmentConfig.Rd
@@ -9,7 +9,7 @@ climateAssessmentConfig(outputDir, mode)
 \arguments{
 \item{outputDir}{A REMIND output directory}
 
-\item{mode}{Determines which probabiliy files is used. Must be either "report", "iteration", or a valid path}
+\item{mode}{Determines which probabiliy files is used. Must be either "report", "iteration" or "impulse"}
 }
 \value{
 A list containing the configuration settings for the climate assessment

--- a/man/emissionDataForClimateAssessment.Rd
+++ b/man/emissionDataForClimateAssessment.Rd
@@ -7,6 +7,7 @@
 emissionDataForClimateAssessment(
   qf,
   scenario,
+  mapping = "AR6",
   variablesFile = NULL,
   logFile = NULL
 )
@@ -15,6 +16,9 @@ emissionDataForClimateAssessment(
 \item{qf}{\code{quitte} data frame containing the emission data}
 
 \item{scenario}{Name of the scenario}
+
+\item{mapping}{Name of the mapping file from the \code{piamInterfaces} library, must be 'AR6', 'NGFS_AR6' or 'AR6_MAgPIE'.
+Defaults to 'AR6'}
 
 \item{variablesFile}{Path to the yaml file containing the variables needed for climate-assessment. If no file path
 is provided, the function gets the yaml file from the piamInterfaces package}


### PR DESCRIPTION
- Removed non-existing `importFrom` statements (`magrittr` does not export `%in%` operator)

In `climateAssessmentConfig.R`:
- `cfg$excludedScenarioFiles`: Climate assessment generates files with `_excluded_scenarios_` in the file name in case certain checks did not pass. Keep potential file locations in config for error checking (idiom could look like `any(file.exists(cfg$excludedScenarioFiles))`)
- Add mode 'impulse'
- Given the provided mode, files generated during a climate assessment run now have distinct file name prefixes
- Added importFrom `read_yaml`, rm'd nonexisting import from `magrittr`
- When running climate assessment in impulse mode the harmonized and infilled emissions file from a previous iteration run is used as basis for the emissions impulse file. Use the `assessmentFilesPrefix` from iteration run config here to emphasize this

In `emissionDataForClimateAssessment.R`:
- For furture mapping tests `emissionDataForClimateAssessment` now forwards the `mapping` parameter to `piamInterfaces::generateIIASASubmission`. Note: Due to the current implementation of this cannot be a file path