### PR TITLE
Forward `reporting` dir

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '222992'
+ValidationKey: '205000'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4
@@ -58,9 +60,31 @@ jobs:
           lucode2::check(runLinter = FALSE)
 
       - name: Test coverage
+        if: ${{ github.event_name != 'pull_request' }}
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) {
+            coverage <- covr::package_coverage(quiet = FALSE)
+            # The following function might be unnecessary if r-lib/covr#616 gets merged
+            to_simple_codecov <- function(coverage) {
+              fullLineCoverage <- covr:::per_line(coverage)
+              data <- Map(function(fileCoverage) {
+                resultCoverage <- lapply(fileCoverage$coverage, jsonlite::unbox)
+                names(resultCoverage) <- seq_along(resultCoverage)
+                return(resultCoverage)
+              }, fullLineCoverage)
+              return(jsonlite::toJSON(list("coverage" = data), na = "null"))
+            }
+            writeLines(to_simple_codecov(coverage), "simple-codecov.json")
+          }
         env:
           NOT_CRAN: "true"
+
+      - uses: codecov/codecov-action@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          file: ./simple-codecov.json
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'remindClimateAssessment: REMIND integration of IIASA''s `climate-assessment`
   package'
-version: 0.0.11
-date-released: '2025-07-03'
+version: 0.1.0
+date-released: '2026-02-16'
 abstract: The REMIND integration of IIASA's `climate-assessment` provides a standardized
   interface to simple climate models such as MAGICC7.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remindClimateAssessment
 Title: REMIND integration of IIASA's `climate-assessment` package
-Version: 0.0.11
-Date: 2025-07-03
+Version: 0.1.0
+Date: 2026-02-16
 Authors@R:
     person("Tonn", "Rüter", , "tonn.rueter@pik-potsdam.de", role = c("aut", "cre"))
 Description: The REMIND integration of IIASA's `climate-assessment` provides a standardized interface to simple climate models such as MAGICC7.
@@ -25,4 +25,4 @@ Imports:
 Suggests:
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/climateAssessmentConfig.R
+++ b/R/climateAssessmentConfig.R
@@ -42,6 +42,7 @@ climateAssessmentConfig <- function(outputDir, mode) {
     condaEnv   = normalizePath(runConfig$pythonPath, mustWork = TRUE),
     isArchived = isTRUE(runConfig$climate_assessment_archive),
     logFile    = normalizePath(file.path(outputDir, "log_climate.txt"), mustWork = FALSE),
+    reportsDir = normalizePath(file.path(outputDir, "reporting"), mustWork = FALSE),
     climateDir = normalizePath(file.path(outputDir, "climate-assessment-data"), mustWork = FALSE),
     workersDir = normalizePath(file.path(outputDir, "climate-assessment-data", "workers"), mustWork = FALSE),
     archiveDir = if (!isTRUE(runConfig$archiveClimateAssessmentData)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # REMIND integration of IIASA's `climate-assessment` package
 
-R package **remindClimateAssessment**, version **0.0.11**
+R package **remindClimateAssessment**, version **0.1.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remindClimateAssessment)](https://cran.r-project.org/package=remindClimateAssessment) [![R build status](https://github.com/pik-piam/remindClimateAssessment/workflows/check/badge.svg)](https://github.com/pik-piam/remindClimateAssessment/actions) [![codecov](https://codecov.io/gh/pik-piam/remindClimateAssessment/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remindClimateAssessment) [![r-universe](https://pik-piam.r-universe.dev/badges/remindClimateAssessment)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Tonn Rüter <tonn.rueter@pik-pots
 
 To cite package **remindClimateAssessment** in publications use:
 
-Rüter T (2025). "remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package." Version: 0.0.11, <https://github.com/pik-piam/remindClimateAssessment>.
+Rüter T (2026). "remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package." Version: 0.1.0, <https://github.com/pik-piam/remindClimateAssessment>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remindClimateAssessment: REMIND integration of IIASA's `climate-assessment` package},
   author = {Tonn Rüter},
-  date = {2025-07-03},
-  year = {2025},
+  date = {2026-02-16},
+  year = {2026},
   url = {https://github.com/pik-piam/remindClimateAssessment},
-  note = {Version: 0.0.11},
+  note = {Version: 0.1.0},
 }
 ```


### PR DESCRIPTION
REMIND run directories may contain a `reporting` dir with additional data (e.g. dumped between iterations) that could be relevant to the climate assessment pipeline. In particular we need to forward it to `reportEmiForClimateAssessement` for compatibility reasons